### PR TITLE
Fix full calendar loading

### DIFF
--- a/modules/AMDLoaderPortlet-web/src/main/resources/META-INF/resources/config.js
+++ b/modules/AMDLoaderPortlet-web/src/main/resources/META-INF/resources/config.js
@@ -2,7 +2,7 @@
 Liferay.Loader.addModule(
 	{
         dependencies: [],
-        name: 'moment.2.18.1',
+        name: 'moment',
         anonymous: true,
         path: MODULE_PATH + '/js/moment.js'
     }
@@ -13,7 +13,6 @@ Liferay.Loader.addModule(
 	{
         dependencies: [],
         name: 'fullCalendar.3.4.0',
-        exports: 'jquery.fn.fullCalendar',
         anonymous: true,
         path: MODULE_PATH + '/js/fullcalendar.js'
     }

--- a/modules/AMDLoaderPortlet-web/src/main/resources/META-INF/resources/html/view.jsp
+++ b/modules/AMDLoaderPortlet-web/src/main/resources/META-INF/resources/html/view.jsp
@@ -35,7 +35,7 @@
 		require ('jquery', function (jquery) {
  			jquery('#prelabel_example1').val('jquery live and kicking');			
 			
- 			require ('moment.2.18.1', function (moment) {
+ 			require ('moment', function (moment) {
  			
  				console.log(moment().format());
  				


### PR DESCRIPTION
Hola Luis!
Reading their source code I've found out that both _moment.js_ and _fullCalendar.js_ are defined as AMD modules.
Don't need to use the _exports_ key.
Try if this works for you too...